### PR TITLE
Fix issues in lidar-camera fusion script

### DIFF
--- a/src/Optimization.cpp
+++ b/src/Optimization.cpp
@@ -8,6 +8,10 @@ Eigen::Matrix4d Optimization::run(const std::vector<Eigen::Vector4d>& lidarPlane
         throw std::runtime_error("Mismatch between the number of LiDAR and camera planes.");
     }
 
+    if (lidarPlanes.size() < 3 || cameraPlanes.size() < 3) {
+        throw std::runtime_error("Not enough valid planes for optimization. At least 3 planes are required.");
+    }
+
     // Step 1: Optimize rotation matrix
     Eigen::Matrix3d rotation = optimizeRotation(lidarPlanes, cameraPlanes);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,19 @@ bool calibrateCamera(const std::vector<std::string>& imageFiles, int checkerboar
     std::cout << "Camera Matrix:\n" << cameraMatrix << std::endl;
     std::cout << "Distortion Coefficients:\n" << distCoeffs.t() << std::endl;
 
+    // Verify the accuracy of the calibration parameters
+    double totalError = 0.0;
+    int totalPoints = 0;
+    for (size_t i = 0; i < objectPoints.size(); ++i) {
+        std::vector<cv::Point2f> projectedPoints;
+        cv::projectPoints(objectPoints[i], rvecs[i], tvecs[i], cameraMatrix, distCoeffs, projectedPoints);
+        double error = cv::norm(imagePoints[i], projectedPoints, cv::NORM_L2);
+        totalError += error * error;
+        totalPoints += objectPoints[i].size();
+    }
+    double meanError = std::sqrt(totalError / totalPoints);
+    std::cout << "Mean reprojection error: " << meanError << std::endl;
+
     return true;
 }
 


### PR DESCRIPTION
Add validation for the number of planes and verify calibration parameters.

* **Optimization.cpp**
  - Add validation for the number of planes in `Optimization::run` before proceeding with optimization.
  - Throw an error if there are fewer than 3 valid planes for optimization.

* **main.cpp**
  - Verify the accuracy of camera calibration parameters in `calibrateCamera`.
  - Calculate and print the mean reprojection error after calibration.

